### PR TITLE
Fix iOS compilation issues with React Native 0.60+

### DIFF
--- a/ios/ReactNativeCountries.podspec
+++ b/ios/ReactNativeCountries.podspec
@@ -9,11 +9,10 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/talut/react-native-countries"
   s.license      = "MIT"
   s.author       = { "author" => "iletisim@taluttasgiran.com.tr" }
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/talut/react-native-countries.git", :tag => "master" }
-  s.source_files = "ReactNativeCountries/**/*.{h,m}"
+  s.source_files = "**/*.{h,m}"
   s.requires_arc = true
-
 
   s.dependency "React"
 


### PR DESCRIPTION
This PR addresses the following:
- iOS source files were not compiling because of incorrect file pattern
- update target version from 7.0 to 9.0 